### PR TITLE
export sfm_data_all.json instead of sfm_data.bin

### DIFF
--- a/src/software/SfM/main_IncrementalSfM.cpp
+++ b/src/software/SfM/main_IncrementalSfM.cpp
@@ -240,10 +240,10 @@ int main(int argc, char **argv)
 
     //-- Export to disk computed scene (data & visualizable results)
     std::cout << "...Export SfM_Data to disk." << std::endl;
-    Save(sfmEngine.Get_SfM_Data(),
+   /* Save(sfmEngine.Get_SfM_Data(),
       stlplus::create_filespec(sOutDir, "sfm_data", ".bin"),
       ESfM_Data(ALL));
-
+   */	
     Save(sfmEngine.Get_SfM_Data(),
       stlplus::create_filespec(sOutDir, "cloud_and_poses", ".ply"),
       ESfM_Data(ALL));
@@ -251,6 +251,10 @@ int main(int argc, char **argv)
     Save(sfmEngine.Get_SfM_Data(),
       stlplus::create_filespec(sOutDir, "sfm_data", ".json"),
       ESfM_Data(VIEWS | EXTRINSICS | INTRINSICS));
+
+    Save(sfmEngine.Get_SfM_Data(),
+      stlplus::create_filespec(sOutDir, "sfm_data_all", ".json"),
+      ESfM_Data(ALL));
 
     return EXIT_SUCCESS;
   }


### PR DESCRIPTION
Changed sfm_data.bin to sfm_data_all.json, so we can modify sfm root path in pipeline script, thus allow moving data between machines.